### PR TITLE
integrate etf-gmlgeox 1.3.3

### DIFF
--- a/testdriver-legacy/build.gradle
+++ b/testdriver-legacy/build.gradle
@@ -11,6 +11,17 @@ ext.basexVersion = '8.6.7'
 ext.deegreeVersion = '3.4.12'
 ext.gmlGeoXVersion = '1.3.3'
 
+repositories{
+
+ ivy {
+        url 'http://github.com/'
+        layout ('pattern') {
+            artifact '[organisation]/[module]/releases/download/[revision]/[module]-[revision].[ext]'
+        }
+    }
+
+}
+
 configurations {
 	api
 	bsxPlugins
@@ -22,7 +33,7 @@ dependencies {
 	compileOnly group: 'de.interactive_instruments.etf', name: 'etf-core', version:'2.1.0'+project.snapshotSuffix
 	compileOnly group: 'de.interactive_instruments.etf', name: 'etf-spi', version:'2.0.0'+project.snapshotSuffix
 	api group: 'org.basex', name: 'basex', version: basexVersion
-  	bsxPlugins group: 'de.interactive_instruments.etf.bsxm', name: 'etf-gmlgeox', version: "$gmlGeoXVersion"+project.snapshotSuffix
+  	bsxPlugins 'etf-validator:etf-gmlgeox:1.3.3:jar'
 
 	compile group: 'commons-logging', name: 'commons-logging', version:'1.1.1'
 	compile group: 'commons-io', name: 'commons-io', version: etf_commonsIoVersion
@@ -88,7 +99,7 @@ jar {
 	into('plugins') {
 		from configurations.bsxPlugins.copy().setTransitive(false)
 		rename { String fileName ->
-			fileName.replaceAll('-(\\d+)\\.(\\d+)\\.(\\d+)(-SNAPSHOT)?', "")
+			fileName.replaceAll('-(\\d+)\\.(\\d+)\\.(\\d+)(-SNAPSHOT)?(-jar)?', "")
 		}
 	}
 }

--- a/testdriver-legacy/build.gradle
+++ b/testdriver-legacy/build.gradle
@@ -33,7 +33,7 @@ dependencies {
 	compileOnly group: 'de.interactive_instruments.etf', name: 'etf-core', version:'2.1.0'+project.snapshotSuffix
 	compileOnly group: 'de.interactive_instruments.etf', name: 'etf-spi', version:'2.0.0'+project.snapshotSuffix
 	api group: 'org.basex', name: 'basex', version: basexVersion
-  	bsxPlugins 'etf-validator:etf-gmlgeox:1.3.3:jar'
+  	bsxPlugins 'etf-validator:etf-gmlgeox:'+gmlGeoXVersion+':jar'
 
 	compile group: 'commons-logging', name: 'commons-logging', version:'1.1.1'
 	compile group: 'commons-io', name: 'commons-io', version: etf_commonsIoVersion


### PR DESCRIPTION
Update to integrate etf-gmlgeox 1.3.3 version from GitHub